### PR TITLE
Parse statistics for Z3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-.DS_Store
+.DS_Store/
+.venv/
+**/__pycache__/
+bin/*/build/
+bench/stats/
+formulae/QF_S/
+formulae/QF_SLIA/
+formulae/QF_SNIA/
+.idea

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -187,11 +187,9 @@ def proc_res(fd, args):
     return
 
 
-###############################
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='''proc_results.py - \
-Processes results of benchmarks from pycobench''')
-    parser.add_argument('results', metavar='result-file', nargs='?',
+def parse_args():
+    parser = argparse.ArgumentParser(description="Processes results of benchmarks from pycobench")
+    parser.add_argument('result_file', nargs='?',
                         help='file with results (output of pycobench) (default: %(default)s)',
                         type=argparse.FileType('r'), default=sys.stdin)
     parser.add_argument('--csv', action="store_true",
@@ -204,4 +202,11 @@ Processes results of benchmarks from pycobench''')
                         help='tick finished benchmarks (usable for filtering)')
     args = parser.parse_args()
 
-    proc_res(args.results, args)
+
+    return args
+
+
+###############################
+if __name__ == '__main__':
+    args = parse_args()
+    proc_res(args.result_file, args)

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -192,8 +192,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='''proc_results.py - \
 Processes results of benchmarks from pycobench''')
     parser.add_argument('results', metavar='result-file', nargs='?',
-                        help='file with results (output of pycobench);'
-                             'if not provided stdin is used')
+                        help='file with results (output of pycobench) (default: %(default)s)',
+                        type=argparse.FileType('r'), default=sys.stdin)
     parser.add_argument('--csv', action="store_true",
                         help='output in CSV')
     parser.add_argument('--text', action="store_true",
@@ -204,11 +204,4 @@ Processes results of benchmarks from pycobench''')
                         help='tick finished benchmarks (usable for filtering)')
     args = parser.parse_args()
 
-    if args.results:
-        fd = open(args.results, "r")
-    else:
-        fd = sys.stdin
-
-    proc_res(fd, args)
-    if args.results:
-        fd.close()
+    proc_res(args.results, args)

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -5,12 +5,24 @@ import argparse
 import csv
 import sys
 from tabulate import tabulate
+from enum import Enum
+from pathlib import Path
+import datetime
+
+from z3_statistics import Z3StatisticsParser, StatsFormat
 
 #  fmt = 'text'
 fmt = 'csv'
 
 # number of parameters of execution
 PARAMS_NUM = 1
+
+
+class RunResult(Enum):
+    """Result of a benchmark instance run."""
+    FINISHED = 1
+    ERROR = 2
+    TIMEOUT = 3
 
 
 ###########################################
@@ -20,6 +32,7 @@ def proc_res(fd, args):
     processes results of pycobench from file descriptor 'fd' using command line
     arguments 'args'
 """
+
     reader = csv.reader(
         fd, delimiter=';', quotechar='"',
         doublequote=False, quoting=csv.QUOTE_MINIMAL)
@@ -27,6 +40,9 @@ def proc_res(fd, args):
     engines = list()
     engines_outs = dict()
     results = dict()
+
+    current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    Path(f"./stats/{current_time}/").mkdir(parents=True, exist_ok=True)
     for row in reader:
         assert len(row) >= 1 + 1 + PARAMS_NUM  # status + engine name + params
         status, eng = row[0], row[1]
@@ -50,25 +66,37 @@ def proc_res(fd, args):
             eng_res["retcode"] = retcode
             eng_res["error"] = err
             eng_res["output"] = dict()
+            eng_res["run_result"] = RunResult.FINISHED
 
             out_lines = out.split("###")
+            reading_inner_block = False
+            inner_block = ""
             for line in out_lines:
-                spl = line.split(':', 1)
-                if len(spl) != 2:  # jump over lines not in the format
-                    continue
-                name, val = spl[0], spl[1]
-                assert name not in eng_res["output"]
-                if name not in engines_outs[eng]:
-                    engines_outs[eng].append(name)
-                eng_res["output"][name] = val
+                if reading_inner_block:
+                    inner_block += line + "\n"
+                    if line.endswith(")"):
+                        reading_inner_block = False
+                        eng_res["output"][f"{engines_outs[eng][-1]}-stats"] = Z3StatisticsParser(inner_block).stats
+                        inner_block = ""
+                elif line.startswith("(:"):
+                    reading_inner_block = True
+                    inner_block += line + "\n"
+                else:
+                    spl = line.split(':', 1)
+                    if len(spl) != 2:  # jump over lines not in the format
+                        continue
+                    name, val = spl[0], spl[1]
+                    assert name not in eng_res["output"]
+                    if name not in engines_outs[eng]:
+                        engines_outs[eng].append(name)
+                    eng_res["output"][name] = val
 
             results[params][eng] = eng_res
+        elif status == 'error':
+            results[params][eng]["run_result"] = RunResult.ERROR
+        elif status == 'timeout':
+            results[params][eng]["run_result"] = RunResult.TIMEOUT
 
-        if status == 'error':
-            results[params][eng] = "ERR"
-
-        if status == 'timeout':
-            results[params][eng] = "TO"
 
     list_ptrns = list()
     for bench in results:
@@ -78,10 +106,15 @@ def proc_res(fd, args):
             out_len = len(engines_outs[eng]) + 1    # +1 = time
             if eng in results[bench]:
                 bench_res = results[bench][eng]
-                if bench_res == "ERR":
+                for out in engines_outs[eng]:
+                    if f"{out}-stats" in bench_res["output"]:
+                        bench_res["output"][f"{out}-stats"] = \
+                            Z3StatisticsParser.stats_formatter(bench_res["output"][f"{out}-stats"], StatsFormat.JSON)
+
+                if bench_res["run_result"] == RunResult.ERROR:
                     for i in range(out_len):
                         ls.append("ERR")
-                elif bench_res == "TO":
+                elif bench_res["run_result"] == RunResult.TIMEOUT:
                     for i in range(out_len):
                         ls.append("TO")
                 else:
@@ -91,7 +124,13 @@ def proc_res(fd, args):
                     ls.append(bench_res["runtime"])
                     for out in engines_outs[eng]:
                         if out in bench_res["output"]:
-                            ls.append(bench_res["output"][out])
+                            out_data = bench_res["output"][out]
+                            ls.append(out_data)
+
+                            if f"{out}-stats" in bench_res["output"]:
+                                stats_file_name = f"{eng}-{bench[0].replace("/", "_").replace(".", "_")}-stats.json"
+                                with open(f"./stats/{current_time}/{stats_file_name}", "w") as f:
+                                    f.write(bench_res["output"][f"{out}-stats"])
                         else:
                             sys.stderr.write("Warning: in {} and {}: "
                                 "element {} not in {}\n".format(bench, eng,
@@ -120,7 +159,10 @@ def proc_res(fd, args):
     for eng in engines:
         header += [eng + "-runtime"]
         for out in engines_outs[eng]:
-            header += [eng + "-" + out]
+            if "stats" in out:
+                header += [eng + "-stats"]
+            else:
+                header += [eng + "-" + out]
 
     fmt = "text"
     if args.csv:

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -210,7 +210,7 @@ def proc_res(fd, args):
 def parse_args():
     parser = argparse.ArgumentParser(description="Processes results of benchmarks from pycobench")
     parser.add_argument('result_file', nargs='?',
-                        help='file with results (output of pycobench) (default: %(default)s)',
+                        help='file with results (output of pycobench) (default: \'%(default)s\')',
                         type=argparse.FileType('r'), default=sys.stdin)
     parser.add_argument('--csv', action="store_true",
                         help='output in CSV')
@@ -222,13 +222,13 @@ def parse_args():
                         help='tick finished benchmarks (usable for filtering)')
     parser.add_argument('--stats-format',
                         choices=list(format_option.name.lower() for format_option in StatsFormat), 
-                        default="json",
-                        help='Which format to use for printing statistics (default: %(default)s)')
-    parser.add_argument('--stats', metavar="STATS_DESTINATION", nargs='?',
+                        default=StatsFormat.JSON.value,
+                        help='Which format to use for printing statistics (default: \'%(default)s\')')
+    parser.add_argument('--stats', nargs='?',
                         choices=list(destination_option.name.lower() for destination_option in StatsDestination),
                         const="results_file", default=None,
                         help='Whether to output statistics and where (default: skipping stats, flag without \
-                              argument: %(const)s)')
+                              argument: \'%(const)s\')')
     args = parser.parse_args()
 
     if args.stats:

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -18,6 +18,11 @@ fmt = 'csv'
 PARAMS_NUM = 1
 
 
+class StatsDestination(Enum):
+    """Output destination for statistics."""
+    RESULTS_FILE = "results_file"
+    SEPARATE_FILES = "separate_files"
+
 class RunResult(Enum):
     """Result of a benchmark instance run."""
     FINISHED = 1
@@ -32,7 +37,6 @@ def proc_res(fd, args):
     processes results of pycobench from file descriptor 'fd' using command line
     arguments 'args'
 """
-
     reader = csv.reader(
         fd, delimiter=';', quotechar='"',
         doublequote=False, quoting=csv.QUOTE_MINIMAL)
@@ -42,7 +46,9 @@ def proc_res(fd, args):
     results = dict()
 
     current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    Path(f"./stats/{current_time}/").mkdir(parents=True, exist_ok=True)
+    if args.stats and args.stats == StatsDestination.SEPARATE_FILES:
+        Path(f"./stats/{current_time}/").mkdir(parents=True, exist_ok=True)
+
     for row in reader:
         assert len(row) >= 1 + 1 + PARAMS_NUM  # status + engine name + params
         status, eng = row[0], row[1]
@@ -67,6 +73,7 @@ def proc_res(fd, args):
             eng_res["error"] = err
             eng_res["output"] = dict()
             eng_res["run_result"] = RunResult.FINISHED
+            name = ""
 
             out_lines = out.split("###")
             reading_inner_block = False
@@ -74,9 +81,16 @@ def proc_res(fd, args):
             for line in out_lines:
                 if reading_inner_block:
                     inner_block += line + "\n"
+
                     if line.endswith(")"):
                         reading_inner_block = False
-                        eng_res["output"][f"{engines_outs[eng][-1]}-stats"] = Z3StatisticsParser(inner_block).stats
+
+                        engine_stats_name = f"{name.removesuffix('-result')}-stats"
+                        assert engine_stats_name not in eng_res["output"]
+                        if engine_stats_name not in engines_outs[eng]:
+                            engines_outs[eng].append(engine_stats_name)
+                        eng_res["output"][engine_stats_name] = Z3StatisticsParser(inner_block).stats
+
                         inner_block = ""
                 elif line.startswith("(:"):
                     reading_inner_block = True
@@ -107,9 +121,10 @@ def proc_res(fd, args):
             if eng in results[bench]:
                 bench_res = results[bench][eng]
                 for out in engines_outs[eng]:
-                    if f"{out}-stats" in bench_res["output"]:
-                        bench_res["output"][f"{out}-stats"] = \
-                            Z3StatisticsParser.stats_formatter(bench_res["output"][f"{out}-stats"], StatsFormat.JSON)
+                    if out.endswith("-stats"):
+                        # if f"{out}-stats" in bench_res["output"]:
+                        bench_res["output"][out] = \
+                            Z3StatisticsParser.stats_formatter(bench_res["output"][out], args.stats_format)
 
                 if bench_res["run_result"] == RunResult.ERROR:
                     for i in range(out_len):
@@ -125,12 +140,19 @@ def proc_res(fd, args):
                     for out in engines_outs[eng]:
                         if out in bench_res["output"]:
                             out_data = bench_res["output"][out]
-                            ls.append(out_data)
 
-                            if f"{out}-stats" in bench_res["output"]:
-                                stats_file_name = f"{eng}-{bench[0].replace("/", "_").replace(".", "_")}-stats.json"
-                                with open(f"./stats/{current_time}/{stats_file_name}", "w") as f:
-                                    f.write(bench_res["output"][f"{out}-stats"])
+                            if out.endswith("-stats"):
+                                if args.stats == StatsDestination.SEPARATE_FILES:
+                                    stats_file_name = f"{eng}-{bench[0].replace('/', '_').replace('.', '_')}-stats.json"
+                                    with open(f"./stats/{current_time}/{stats_file_name}", "w") as f:
+                                        f.write(out_data)
+                                elif args.stats == StatsDestination.RESULTS_FILE:
+                                    if args.csv:
+                                       out_data = out_data.replace("\n", "###")
+                                    ls.append(out_data)
+                            else:
+                                ls.append(out_data)
+
                         else:
                             sys.stderr.write("Warning: in {} and {}: "
                                 "element {} not in {}\n".format(bench, eng,
@@ -159,10 +181,9 @@ def proc_res(fd, args):
     for eng in engines:
         header += [eng + "-runtime"]
         for out in engines_outs[eng]:
-            if "stats" in out:
-                header += [eng + "-stats"]
-            else:
-                header += [eng + "-" + out]
+            if out.endswith("-stats") and args.stats != StatsDestination.RESULTS_FILE:
+                continue
+            header += [eng + "-" + out]
 
     fmt = "text"
     if args.csv:
@@ -184,7 +205,6 @@ def proc_res(fd, args):
         writer.writerows(list_ptrns)
     else:
         raise Exception('Invalid output format: "{}"'.format(fmt))
-    return
 
 
 def parse_args():
@@ -200,8 +220,21 @@ def parse_args():
                         help='output in HTML')
     parser.add_argument('--tick', action="store_true",
                         help='tick finished benchmarks (usable for filtering)')
+    parser.add_argument('--stats-format',
+                        choices=list(format_option.name.lower() for format_option in StatsFormat), 
+                        default="json",
+                        help='Which format to use for printing statistics (default: %(default)s)')
+    parser.add_argument('--stats', metavar="STATS_DESTINATION", nargs='?',
+                        choices=list(destination_option.name.lower() for destination_option in StatsDestination),
+                        const="results_file", default=None,
+                        help='Whether to output statistics and where (default: skipping stats, flag without \
+                              argument: %(const)s)')
     args = parser.parse_args()
 
+    if args.stats:
+        args.stats = StatsDestination[args.stats.upper()]
+    if args.stats_format:
+        args.stats_format = StatsFormat[args.stats_format.upper()]
 
     return args
 

--- a/bench/pyco_proc
+++ b/bench/pyco_proc
@@ -85,7 +85,7 @@ def proc_res(fd, args):
                     spl = line.split(':', 1)
                     if len(spl) != 2:  # jump over lines not in the format
                         continue
-                    name, val = spl[0], spl[1]
+                    name, val = spl[0].strip(), spl[1].strip()
                     assert name not in eng_res["output"]
                     if name not in engines_outs[eng]:
                         engines_outs[eng].append(name)

--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -111,10 +111,12 @@ do
 done
 
 tasks_files=()
+
 for benchmark in "${benchmarks[@]}"; do
 	echo "Running benchmark $benchmark"
 	CUR_DATE=$(date +%Y-%m-%d-%H-%M)
-	TASKS_FILE="$benchmark-to120-$tool-$CUR_DATE.tasks"
+	FILE_PREFIX="$benchmark-to120-$tool-$CUR_DATE"
+	TASKS_FILE="$FILE_PREFIX.tasks"
 	cat "$benchmark.input" | ./pycobench -c smt.yaml -j $j_value -t 120 --memout $m_value -m "$tool" -o "$TASKS_FILE"
 	tasks_files+=("$TASKS_FILE")
 	echo "$TASKS_FILE" >> tasks_names.txt

--- a/bench/smt.yaml
+++ b/bench/smt.yaml
@@ -43,6 +43,9 @@ z3-noodler-model:
 z3-noodler-length:
   cmd: ../bin/z3-noodler-wrap.sh smt.str.try_length_proc=true $1
 
+z3-noodler-stats:
+  cmd: ../bin/z3-noodler-wrap.sh -st $1
+
 cvc4:
   cmd: ../bin/cvc4-wrap.sh $1
 

--- a/bench/z3_statistics.py
+++ b/bench/z3_statistics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import json
+import io
+from enum import Enum
+
+
+class StatsFormat(Enum):
+    JSON = "json"
+    # HTML = "html"
+    # CSV = "csv"
+    # TSV = "tsv"
+
+
+class Z3StatisticsParser:
+    def __init__(self, input_data: str | bytes):
+        self._input_data: list[str] = input_data.splitlines()
+        self._stats: dict = {}
+
+        self.__parse_statistics()
+
+    @staticmethod
+    def stats_formatter(stats: dict, format: StatsFormat = StatsFormat.JSON) -> str:
+        if format == StatsFormat.JSON:
+            return json.dumps(stats, indent=2, sort_keys=True)
+    
+    @staticmethod
+    def __decode_stat_value(value: str) -> int | float | str:
+        valid_value_types = [int, float, str]
+        for value_type_conversion_function in valid_value_types:
+            try:
+                result = value_type_conversion_function(value)
+            except ValueError:
+                continue
+        return value
+
+    def __parse_statistics(self) -> None:
+        reading_stats = False
+        for line in self._input_data:
+            if not reading_stats and line.startswith("(:"):
+                reading_stats = True
+
+            if reading_stats:
+                if line.endswith(")"):
+                    reading_stats = False
+                line = line.replace("(", "").replace(")", "").replace(":", "").split()
+                self._stats[line[0]] = (self.__decode_stat_value(line[1]))
+
+    @property
+    def stats(self) -> dict:
+        return self._stats
+
+    def print_stats(self, stats_file: io.TextIOWrapper | None = None, format: StatsFormat = StatsFormat.JSON) -> None:
+        formatted_stats = Z3StatisticsParser.stats_formatter(stats=self.stats, format=format)
+        formatted_stats += "\n"
+        if stats_file:
+            stats_file.write(formatted_stats)
+        else:
+            print(formatted_stats)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Z3 statistics parser")
+    parser.add_argument("statistics_file", help="File with Z3 output with statistics to parse (default: \'<stdin>\')", nargs="?", type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("-o", "--output", help="Output file to print the parsed Z3 statistics (default: \'<stdout>\')", nargs="?", type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('--format',
+                        choices=list(format_option.name.lower() for format_option in StatsFormat),
+                        default=StatsFormat.JSON.value,
+                        help='Which format to use for printing statistics (default: \'%(default)s\')')
+    args = parser.parse_args()
+
+    if args.format:
+        args.format = StatsFormat[args.format.upper()]
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    Z3StatisticsParser(input_data=args.statistics_file.read()) \
+        .print_stats(stats_file=args.output, format=args.format)


### PR DESCRIPTION
This PR implements parsing statistics from the benchmark runs for SMT solver Z3.

A new script `bench/z3_statistics.py` is added. It allows parsing statistics from Z3. One can run `<path_to_z3>/z3 ... | ./z3_statistics.py` to automatically parse the output of a run of Z3, or run `./z3_statistics.py <path_to_file_with_statistics>`. As of now, the solver supports printing statistics to JSON format, but other formats may be added. 

For the integration with pycobench, a new (possibly temporary) task `z3-noodler-stats` in `smt.yaml` was created. We should discuss how and when we want to collect statistics (enabled in Z3 with argument `-st` to the `z3` binary). Furthermore, `pyco_proc` has been updated to process and store formatted statistics if they are present.

TODO: We currently use `pyco_proc` from https://github.com/VeriFIT/smt-string-bench-results, which means that we will have to copy the code of `pyco_proc` over to the other repo as well.

Note: The implementation works with quite a few presumptions about the output format of other solvers. The implementation should work for any solver if the appropriate task and parser for statistics of the given solver is implemented.

@vhavlena Could you have a look at the code and try to run it to see how we like the results?