### PR TITLE
Merge `pyco_proc.py` with its version from VeriFIT/smt-string-bench-results

### DIFF
--- a/bench/pyco_proc.py
+++ b/bench/pyco_proc.py
@@ -5,6 +5,7 @@ import argparse
 import csv
 import sys
 from tabulate import tabulate
+import io
 from enum import Enum
 from pathlib import Path
 import datetime
@@ -15,13 +16,14 @@ from z3_statistics import Z3StatisticsParser, StatsFormat
 fmt = 'csv'
 
 # number of parameters of execution
-PARAMS_NUM = 1
+__PYCO_PROC_PARAMS_NUM = 1
 
 
 class StatsDestination(Enum):
     """Output destination for statistics."""
-    RESULTS_FILE = "results_file"
+    OUTPUT_FILE = "output_file"
     SEPARATE_FILES = "separate_files"
+
 
 class RunResult(Enum):
     """Result of a benchmark instance run."""
@@ -34,7 +36,7 @@ class RunResult(Enum):
 def proc_res(fd, args):
     """proc_res(fd, args) -> _|_
 
-    processes results of pycobench from file descriptor 'fd' using command line
+    processes results of pycobench.py from file descriptor 'fd' using command line
     arguments 'args'
 """
     reader = csv.reader(
@@ -50,15 +52,16 @@ def proc_res(fd, args):
         Path(f"./stats/{current_time}/").mkdir(parents=True, exist_ok=True)
 
     for row in reader:
-        assert len(row) >= 1 + 1 + PARAMS_NUM  # status + engine name + params
+        assert len(row) >= 1 + 1 + __PYCO_PROC_PARAMS_NUM  # status + engine name + params
         status, eng = row[0], row[1]
-        params = tuple(row[2:(PARAMS_NUM+2)])
-        row_tail = row[(PARAMS_NUM+2):]
+        params = tuple(row[2:(__PYCO_PROC_PARAMS_NUM+2)])
+        row_tail = row[(__PYCO_PROC_PARAMS_NUM+2):]
         if params not in results:
             results[params] = dict()
         if eng not in engines:
             engines.append(eng)
             engines_outs[eng] = list()
+            # engines_outs[eng] = ["result"]
 
         # we don't have some results twice
         assert eng not in results[params]
@@ -75,6 +78,7 @@ def proc_res(fd, args):
             eng_res["run_result"] = RunResult.FINISHED
             name = ""
 
+            # out_lines = [out]
             out_lines = out.split("###")
             reading_inner_block = False
             inner_block = ""
@@ -100,6 +104,7 @@ def proc_res(fd, args):
                     if len(spl) != 2:  # jump over lines not in the format
                         continue
                     name, val = spl[0].strip(), spl[1].strip()
+
                     assert name not in eng_res["output"]
                     if name not in engines_outs[eng]:
                         engines_outs[eng].append(name)
@@ -122,7 +127,6 @@ def proc_res(fd, args):
                 bench_res = results[bench][eng]
                 for out in engines_outs[eng]:
                     if out.endswith("-stats"):
-                        # if f"{out}-stats" in bench_res["output"]:
                         bench_res["output"][out] = \
                             Z3StatisticsParser.stats_formatter(bench_res["output"][out], args.stats_format)
 
@@ -146,7 +150,7 @@ def proc_res(fd, args):
                                     stats_file_name = f"{eng}-{bench[0].replace('/', '_').replace('.', '_')}-stats.json"
                                     with open(f"./stats/{current_time}/{stats_file_name}", "w") as f:
                                         f.write(out_data)
-                                elif args.stats == StatsDestination.RESULTS_FILE:
+                                elif args.stats == StatsDestination.OUTPUT_FILE:
                                     if args.csv:
                                        out_data = out_data.replace("\n", "###")
                                     ls.append(out_data)
@@ -154,9 +158,8 @@ def proc_res(fd, args):
                                 ls.append(out_data)
 
                         else:
-                            sys.stderr.write("Warning: in {} and {}: "
-                                "element {} not in {}\n".format(bench, eng,
-                                out, bench_res["output"]))
+                            sys.stderr.write(f"Warning: in {bench} and {eng}: element {out} not in "
+                                             f"{bench_res['output']}\n")
                             ls.append("MISSING")
                             # assert False
             else:
@@ -181,9 +184,10 @@ def proc_res(fd, args):
     for eng in engines:
         header += [eng + "-runtime"]
         for out in engines_outs[eng]:
-            if out.endswith("-stats") and args.stats != StatsDestination.RESULTS_FILE:
+            if out.endswith("-stats") and args.stats != StatsDestination.OUTPUT_FILE:
                 continue
             header += [eng + "-" + out]
+            # header += [eng + "-result"]
 
     fmt = "text"
     if args.csv:
@@ -194,24 +198,27 @@ def proc_res(fd, args):
         fmt = "html"
 
     if fmt == 'html':
-        print(tabulate(list_ptrns, header, tablefmt='html'))
+        return tabulate(list_ptrns, header, tablefmt='html')
     elif fmt == 'text':
-        print(tabulate(list_ptrns, header, tablefmt='text'))
+        return tabulate(list_ptrns, header, tablefmt='text')
     elif fmt == 'csv':
+        output = io.StringIO()
         writer = csv.writer(
-            sys.stdout, delimiter=';', quotechar='"', escapechar='\\',
+            output, delimiter=';', quotechar='"', escapechar='\\',
             doublequote=False, quoting=csv.QUOTE_MINIMAL)
         writer.writerow(header)
         writer.writerows(list_ptrns)
+        return output.getvalue()
     else:
         raise Exception('Invalid output format: "{}"'.format(fmt))
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Processes results of benchmarks from pycobench")
+    parser = argparse.ArgumentParser(description="Processes results of benchmarks from pycobench.py")
     parser.add_argument('result_file', nargs='?',
-                        help='file with results (output of pycobench) (default: \'%(default)s\')',
+                        help='file with results (output of pycobench.py) (default: \'<stdin>\')',
                         type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("-o", "--output", help="Output file to print the parsed results (default: \'<stdout>\')", nargs="?", type=argparse.FileType('w'), default=sys.stdout)
     parser.add_argument('--csv', action="store_true",
                         help='output in CSV')
     parser.add_argument('--text', action="store_true",
@@ -226,7 +233,7 @@ def parse_args():
                         help='Which format to use for printing statistics (default: \'%(default)s\')')
     parser.add_argument('--stats', nargs='?',
                         choices=list(destination_option.name.lower() for destination_option in StatsDestination),
-                        const="results_file", default=None,
+                        const="output_file", default=None,
                         help='Whether to output statistics and where (default: skipping stats, flag without \
                               argument: \'%(const)s\')')
     args = parser.parse_args()
@@ -242,4 +249,5 @@ def parse_args():
 ###############################
 if __name__ == '__main__':
     args = parse_args()
-    proc_res(args.result_file, args)
+    processed_results = proc_res(args.result_file, args)
+    args.output.write(processed_results)

--- a/bench/pycobench.py
+++ b/bench/pycobench.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# pycobench - a small benchmarking solution
+# pycobench.py - a small benchmarking solution
 #
 # A small environment for running benchmarks
 #
@@ -495,9 +495,7 @@ Runs the main program according to the arguments obtained from the parser.
 ###########################################
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-                description="pycobench - "
-                "Executes benchmarks given using a configuration file on "
-                "cases given in input")
+                description="Executes benchmarks given using a configuration file on cases given in input")
     parser.add_argument('-j', '--jobs', type=int, default=os.cpu_count(),
                         help='The number of jobs (workers) to run '
                         'concurrently (default: %(default)s)')

--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -117,7 +117,7 @@ for benchmark in "${benchmarks[@]}"; do
 	CUR_DATE=$(date +%Y-%m-%d-%H-%M)
 	FILE_PREFIX="$benchmark-to120-$tool-$CUR_DATE"
 	TASKS_FILE="$FILE_PREFIX.tasks"
-	cat "$benchmark.input" | ./pycobench -c smt.yaml -j $j_value -t 120 --memout $m_value -m "$tool" -o "$TASKS_FILE"
+	cat "$benchmark.input" | ./pycobench.py -c smt.yaml -j $j_value -t 120 --memout $m_value -m "$tool" -o "$TASKS_FILE"
 	tasks_files+=("$TASKS_FILE")
 	echo "$TASKS_FILE" >> tasks_names.txt
 done

--- a/bench/z3_statistics.py
+++ b/bench/z3_statistics.py
@@ -52,13 +52,10 @@ class Z3StatisticsParser:
     def stats(self) -> dict:
         return self._stats
 
-    def print_stats(self, stats_file: io.TextIOWrapper | None = None, format: StatsFormat = StatsFormat.JSON) -> None:
+    def print_stats(self, stats_file: io.TextIOWrapper, format: StatsFormat = StatsFormat.JSON) -> None:
         formatted_stats = Z3StatisticsParser.stats_formatter(stats=self.stats, format=format)
         formatted_stats += "\n"
-        if stats_file:
-            stats_file.write(formatted_stats)
-        else:
-            print(formatted_stats)
+        stats_file.write(formatted_stats)
 
 
 def parse_args():


### PR DESCRIPTION
This PR tries to merge `pyco_proc.py` with its version in VeriFIT/smt-string-bench-results. It seems that there are some issues that we will have to figure out on the go. From the data I gathered, this should be how it should work. Some tools, however, may output some incorrectly formatted output which may break things. I need someone to try all the usual operations and see whether something breaks.

The commented-out lines represent some of the changes in VeriFIT/smt-string-bench-results which might be relevant for fixing the tools with the incorrect output, but breaking other stuff.