### PR TITLE
Cpu Affinity Parameter

### DIFF
--- a/bench/pycobench.py
+++ b/bench/pycobench.py
@@ -95,9 +95,11 @@ g_cpu_affinity = list(range(os.cpu_count()))  # by default, all CPUs
 g_bind_to_cpu = False
 
 #############################################
-# If g_bind_to_cpu is True, then each worker is pinned to a specific CPU;
-# otherwise, all workers can use all CPUs in g_cpu_affinity
+
 def get_cpu_affiliation(worker_idx):
+    """ If g_bind_to_cpu is True, then each worker is pinned to a specific CPU;
+    otherwise, all workers can use all CPUs in g_cpu_affinity
+    """
     if not g_bind_to_cpu:
         return g_cpu_affinity
     return [g_cpu_affinity[worker_idx % len(g_cpu_affinity)]]
@@ -174,7 +176,7 @@ def limit_virtual_memory(cpu_affinity):
 
 ###########################################
 def run_subproc_systime(cmd, cpu_affinity):
-    """run_subproc(cmd) -> dict()
+    """run_subproc(cmd, cpu_affinity) -> dict()
 
 Runs a command as a subprocess and collects results.  The time consumed is
 measured using system "time" command.
@@ -245,7 +247,7 @@ measured using system "time" command.
 
 ###########################################
 def execute_benchmark(params, cpu_affinity):
-    """execute_benchmark(params) -> None
+    """execute_benchmark(params, cpu_affinity) -> None
 
 Executes one benchmark.
 """
@@ -291,7 +293,7 @@ def merge_two_dicts(x, y):
 
 ###########################################
 def worker(cpu_affinity):
-    """worker() -> None
+    """worker(cpu_affinity) -> None
 
 Main function of a thread for processing tasks.
 """

--- a/bench/pycobench.py
+++ b/bench/pycobench.py
@@ -95,7 +95,8 @@ g_cpu_affinity = list(range(os.cpu_count()))  # by default, all CPUs
 g_bind_to_cpu = False
 
 #############################################
-# if g_cpu_affinity is not empty, pin the thread to a specific CPU
+# If g_bind_to_cpu is True, then each worker is pinned to a specific CPU;
+# otherwise, all workers can use all CPUs in g_cpu_affinity
 def get_cpu_affiliation(worker_idx):
     if not g_bind_to_cpu:
         return g_cpu_affinity
@@ -438,7 +439,7 @@ Runs the main program according to the arguments obtained from the parser.
     g_verbose = args.verbose
     global g_cpu_affinity
     if args.cpu_affinity is not None:
-        g_cpu_affinity = sorted(set(args.cpu_affinity))
+        g_cpu_affinity = args.cpu_affinity
     global g_bind_to_cpu
     g_bind_to_cpu = args.bind_to_cpu
 
@@ -540,9 +541,9 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--conf', metavar='config.yaml', nargs=1, required=True,
                         help='configuration file (in YAML)')
     parser.add_argument('--cpu-affinity', type=int, nargs='+',
-                        help="set CPU affinity to the given list of CPUs (0-based)")
+                        help="Set CPU affinity to the given list of CPUs.")
     parser.add_argument('--bind-to-cpu', action='store_true', default=False,
-                        help="pin each worker thread to a specific CPU; good to combine with --cpu-affinity")
+                        help="Pin each worker thread to a specific CPU.")
     parser.add_argument('input', nargs="?",
                         help="input file with the tasks in CSV (default: %(default)s)",
                         type=argparse.FileType('r'), default=sys.stdin)

--- a/bench/run_bench.sh
+++ b/bench/run_bench.sh
@@ -26,8 +26,8 @@ show_help() {
 	echo "  -j N    How many processes to run in parallel (default=8)"
 	echo "  -m N    Memory limit of each process in GB (default=8)"
 	echo "  -s N    Timeout for each process in seconds (default=120)"
-	echo "  --bind-to-cpu  Bind each worker thread to a specific CPU; good to combine with --cpu-affinity"
-	echo "  --cpu-affinity c1,c2,c3 Pin processes to specific CPU cores (default=all)"
+	echo "  --cpu-affinity c0,c1,c2 Pin processes to specific CPU cores (default=all)."
+	echo "  --bind-to-cpu  Bind each worker thread to a specific CPU."
 }
 
 REGEX=("sygus_qgen" "denghang" "automatark" "stringfuzz" "redos" "matching" "hornstr")
@@ -99,7 +99,6 @@ while getopts "ht:j:m:s:-:" option; do
             ;;
     esac
 done
-
 # Handle optional CPU affinity argument
 cpu_affinity_arg=""
 if [ -n "$cpu_affinity" ]; then


### PR DESCRIPTION
This PR extends the parameters and functionality of `pycobench.py` and `run_bench.sh` by introducing two new options:  
- `--cpu-affinity`: Specifies a list of CPUs on which the benchmark will run.  
- `--bind-to_cpu`: Forces a benchmarking thread to remain on the CPU it started on, preventing migration to other CPUs.  

**The purpose of these extensions is to:**
1. Give finer control over CPU scheduling and achieve more consistent benchmark results.  
2. Mitigate the effects of heterogeneous cores on modern CPUs (e.g., Performance cores, Efficient cores, Low-Power cores).  
3. Avoid nondeterministic slowdowns on machines with hyperthreading enabled.  
4. Control process placement to prevent delays caused by threads moving to new CPUs and leaving data behind.  

**Potential issues without CPU restrictions:**
1. On modern CPUs, benchmarking processes can unpredictably run on Efficient or Low-Power cores, leading to inconsistent results.  
2. On hyperthreaded machines, the scheduler may assign multiple threads to a single physical core, causing slowdowns due to higher temperatures of the core and resource sharing.
3. Even without hyperthreading, on machines with many cores (cca twice the number of benchmarking jobs), the scheduler can move processes to other cores (e.g., due to temperature, ...), leaving data and resulting in slower execution.  

**An example** of (in)consistent results for different CPU affinity settings on my machine (8 physical / 16 logical cores): The difference between no and best affinity was cca 40 seconds, and one solved benchmark more.

```
# of formulae: 772; z3-noodler-7ce2cff-f09b1eb; jobs=4; timeout=120s; memory=8GB
ORIGINAL: The newest results from `VeriFIT/smt-string-bench-results`.
Ph: all physical cores
4Ph: 4 physical cores
2Ph: 2 physical cores with hyperthreading (4 logical cores)
bind: A benchmarking thread cannot leave the core on which it started.
unbind: A benchmarking thread can move to any assigned core.

Cpu model: AMD Ryzen™ 7 3800XT × 16
CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE    MAXMHZ   MINMHZ       MHZ  all  Ph  4Ph  2Ph
  0    0      0    0 0:0:0:0          ano 5332,0000 550,0000 1959,0000   *    *
  1    0      0    1 1:1:1:0          ano 5332,0000 550,0000 1959,0000   *    *   *    *
  2    0      0    2 2:2:2:0          ano 5332,0000 550,0000 4400,2539   *    *   *    *
  3    0      0    3 3:3:3:0          ano 5332,0000 550,0000 4400,2061   *    *
  4    0      0    4 4:4:4:1          ano 5332,0000 550,0000 4400,3140   *    *   *
  5    0      0    5 5:5:5:1          ano 5332,0000 550,0000 1959,0000   *    *   *
  6    0      0    6 6:6:6:1          ano 5332,0000 550,0000 1959,0000   *    *
  7    0      0    7 7:7:7:1          ano 5332,0000 550,0000 1959,0000   *    *
  8    0      0    0 0:0:0:0          ano 5332,0000 550,0000 1959,0000   *
  9    0      0    1 1:1:1:0          ano 5332,0000 550,0000 1959,0000   *             *
 10    0      0    2 2:2:2:0          ano 5332,0000 550,0000 1959,0000   *             *
 11    0      0    3 3:3:3:0          ano 5332,0000 550,0000 1959,0000   *
 12    0      0    4 4:4:4:1          ano 5332,0000 550,0000 1959,0000   *
 13    0      0    5 5:5:5:1          ano 5332,0000 550,0000 1959,0000   *
 14    0      0    6 6:6:6:1          ano 5332,0000 550,0000 1959,0000   *
 15    0      0    7 7:7:7:1          ano 5332,0000 550,0000 1959,0000   *

--------------------------------------------------
tool                          ✅    ❌    time    avg    med    std    sat    unsat    unknown    TO    MO+ERR    other
--------------------------  ----  ----  ------  -----  -----  -----  -----  -------  ---------  ----  --------  -------
ORIGINAL                     720    52  549.05   0.76   0.01   5.46    287      433          1    49         2        0

unbind all                   721    51  628.14   0.87   0.00   6.68    288      433          1    49         1        0
unbind all                   720    52  515.75   0.72   0.00   5.08    287      433          1    50         1        0

unbind to Ph                 720    52  508.82   0.71   0.00   5.01    287      433          1    49         2        0
unbind to Ph                 721    51  628.89   0.87   0.00   6.68    288      433          1    48         2        0
unbind to Ph                 721    51  626.93   0.87   0.00   6.67    288      433          1    49         1        0

bind to 4Ph                  721    51  592.06   0.82   0.00   6.32    288      433          1    48         2        0
bind to 4Ph                  721    51  592.15   0.82   0.00   6.32    288      433          1    48         2        0
bind to 4Ph                  721    51  590.16   0.82   0.00   6.32    288      433          1    48         2        0

unbind to 4Ph                721    51  588.57   0.82   0.00   6.30    288      433          1    48         2        0
unbind to 4Ph                721    51  587.22   0.81   0.00   6.27    288      433          1    48         2        0

unbind to 2Ph                720    52  703.60   0.98   0.01   7.04    287      433          1    50         1        0
bind to 2Ph                  719    53  667.66   0.93   0.01   6.94    286      433          1    51         1        0
--------------------------------------------------


Benchmark webapp
# of formulae: 681
--------------------------------------------------
tool                          ✅    ❌    time    avg    med    std    sat    unsat    unknown    TO    MO+ERR    other
--------------------------  ----  ----  ------  -----  -----  -----  -----  -------  ---------  ----  --------  -------
ORIGINAL                     679     2   78.87   0.12   0.00   1.91    250      429          1     1         0        0

unbind all                   679     2   71.82   0.11   0.00   1.54    250      429          1     1         0        0
unbind all                   679     2   73.31   0.11   0.00   1.56    250      429          1     1         0        0

unbind to Ph                 679     2   73.40   0.11   0.00   1.54    250      429          1     1         0        0
unbind to Ph                 679     2   74.40   0.11   0.00   1.57    250      429          1     1         0        0
unbind to Ph                 679     2   73.38   0.11   0.00   1.54    250      429          1     1         0        0

bind to 4Ph                  679     2   71.30   0.11   0.00   1.54    250      429          1     1         0        0
bind to 4Ph                  679     2   71.99   0.11   0.00   1.53    250      429          1     1         0        0
bind to 4Ph                  679     2   71.08   0.10   0.00   1.53    250      429          1     1         0        0

unbind to 4Ph                679     2   70.11   0.10   0.00   1.52    250      429          1     1         0        0
unbind to 4Ph                679     2   71.64   0.11   0.00   1.53    250      429          1     1         0        0

unbind to 2Ph                679     2   85.35   0.13   0.01   1.59    250      429          1     1         0        0
bind to 2Ph                  678     3   45.01   0.07   0.01   0.53    249      429          1     2         0        0
--------------------------------------------------


Benchmark transducer_plus
# of formulae: 91
--------------------------------------------------
tool                          ✅    ❌    time    avg    med    std    sat    unsat    unknown    TO    MO+ERR    other
--------------------------  ----  ----  ------  -----  -----  -----  -----  -------  ---------  ----  --------  -------
ORIGINAL                      41    50  470.18  11.47   0.27  18.69     37        4          0    48         2        0

unbind all                    42    49  556.32  13.25   0.34  24.06     38        4          0    48         1        0
unbind all                    41    50  442.44  10.79   0.27  17.69     37        4          0    49         1        0

unbind to Ph                  41    50  435.42  10.62   0.28  17.43     37        4          0    48         2        0
unbind to Ph                  42    49  554.49  13.20   0.33  24.02     38        4          0    47         2        0
unbind to Ph                  42    49  553.55  13.18   0.33  24.01     38        4          0    48         1        0

bind to 4Ph                   42    49  520.76  12.40   0.31  22.75     38        4          0    47         2        0
bind to 4Ph                   42    49  520.16  12.38   0.30  22.75     38        4          0    47         2        0
bind to 4Ph                   42    49  519.08  12.36   0.30  22.76     38        4          0    47         2        0

unbind to 4Ph                 42    49  518.46  12.34   0.32  22.66     38        4          0    47         2        0
unbind to 4Ph                 42    49  515.58  12.28   0.30  22.56     38        4          0    47         2        0

unbind to 2Ph                 41    50  618.25  15.08   0.36  25.13     37        4          0    49         1        0
bind to 2Ph                   41    50  622.65  15.19   0.37  25.30     37        4          0    49         1        0
--------------------------------------------------
```

Based on this observation, for consistent benchmarking results (even on machines without hyperthreading), I propose always setting `--cpu-affinity` to `N` unique (well-separated physical cores) where `N` is the number of parallel benchmarking jobs.
